### PR TITLE
Fixed the CSS so that class names are the same as in main.

### DIFF
--- a/skills/templates/skills/demand-vs-knowledge.html
+++ b/skills/templates/skills/demand-vs-knowledge.html
@@ -4,7 +4,7 @@
 
 {% include "skills/snippets/team-members.html" %}
 
-<div class="t-row-off">
+<div class="t-row">
     <div class="t-cell t-header skills-row-header"><em>How to read this?  See <a href="#howto">below</a>.</em></div>
     <div class="t-cell t-header skills-column-header skills-cell-right">← Demand</div>
     <div class="t-cell t-header skills-column-header">Team knowledge and interest →</div>
@@ -14,14 +14,14 @@
     {% if skill.category_title %}
         <h2>{{ skill.category_title }}</h2>
     {% endif %}
-    <div class="t-row">
+    <div class="t-row-nth">
         <div class="t-cell t-header skills-row-header"><a href="{% url 'skills:skill' skill.skill %}">{{ skill.title }}</a></div>
         {% if skill.bar_length %}
             <div class="t-cell skills-cell-right">
                 <div class="t-cell skills-demand-bar" style="width: {{ skill.bar_length }}%">&nbsp;{{ skill.count }}</div>
             </div>
             <div class="t-cell skills-cell-left">
-                <div class="t-row-off">
+                <div class="t-row">
                     {% for level in skill.knowledge %}
                         {% if level %}
                             <div class="t-cell skills-knowledge-{{ forloop.counter }} skills-cell-narrow skills-thin-bar">{{ level }}</div>
@@ -33,7 +33,7 @@
                         <div class="t-cell skills-cell-narrow skills-thin-bar">&star;</div>
                     {% endif %}
                 </div>
-                <div class="t-row-off">
+                <div class="t-row">
                     {% for level in skill.interest %}
                         {% if level %}
                             <div class="t-cell skills-interest-right-{{ forloop.counter }} skills-cell-narrow skills-thin-bar">{{ level }}</div>
@@ -62,7 +62,7 @@
 
 <p>Here is the example.</p>
 
-<div class="t-row-off">
+<div class="t-row">
     <div class="t-cell t-header skills-row-header"><u>Django framework</u></div>
     <div class="t-cell skills-cell-right">
         <div class="t-cell skills-demand-bar" style="width: 65%">&nbsp;5</div>

--- a/skills/templates/skills/interest-vs-knowledge.html
+++ b/skills/templates/skills/interest-vs-knowledge.html
@@ -6,7 +6,7 @@
 
 {% include "skills/snippets/team-members.html" %}
 
-<div class="t-row-off">
+<div class="t-row">
     <div class="t-cell t-header skills-row-header"><em>How to read this?  See <a href="#howto">below</a>.</em></div>
     <div class="t-cell t-header skills-column-header skills-cell-right">← Interest</div>
     <div class="t-cell t-header skills-column-header">Knowledge →</div>
@@ -16,7 +16,7 @@
     {% if skill.category_title %}
         <h2>{{ skill.category_title }}</h2>
     {% endif %}
-    <div class="t-row">
+    <div class="t-row-nth">
         <div class="t-cell t-header skills-row-header"><a href="{% url 'skills:skill' skill.skill %}">{{ skill.title }}</a></div>
         <div class="t-cell skills-cell-right">
             {% for level in skill.interest %}
@@ -57,7 +57,7 @@
 
 <p>Here is the example.</p>
 
-<div class="t-row-off">
+<div class="t-row">
     <div class="t-cell t-header skills-row-header"><u>Django framework</u></div>
     <div class="t-cell skills-cell-right">
         <div class="t-cell skills-interest-1 skills-cell-narrow">2</div>

--- a/skills/templates/skills/projects.html
+++ b/skills/templates/skills/projects.html
@@ -7,7 +7,7 @@
 {% include "skills/snippets/team-members.html" %}
 
 {% if projects %}
-    <div class="t-row-off">
+    <div class="t-row">
         <div class="t-cell t-header skills-project-row-header">Project</div>
         <div class="t-cell t-header skills-project-skills-column-header">Skills</div>
         <div class="t-cell t-header skills-project-status-column-header">Active</div>
@@ -17,7 +17,7 @@
 {% endif %}
 
 {% for project in projects %}
-    <div class="t-row">
+    <div class="t-row-nth">
         <div class="t-cell t-header skills-project-row-header">
             <a href="{% url 'skills:project' project.project.pk %}">{{ project.project.name }}</a>
         </div>

--- a/static/style.css
+++ b/static/style.css
@@ -31,12 +31,12 @@ a:hover {
 
 /* Forms and tables are rendered using DIVs. */
 
-.t-row, .t-row-off {
+.t-row, .t-row-nth {
     width: 100%;
     display: table;
 }
 
-.t-row:nth-child(even) {
+.t-row-nth:nth-child(even) {
     background-color: #f8f8f8;
 }
 


### PR DESCRIPTION
This is related to #77 and fixes issues that we have in stable after the previous commit.

The layout messed up because the updated template used a class that was renamed in main but not in stable.

This patch fixes the naming.