### PR TITLE
Added the templates for rendering and editing personal contributions

### DIFF
--- a/people/templates/people/contribution.html
+++ b/people/templates/people/contribution.html
@@ -1,0 +1,34 @@
+{% extends "people/base.html" %}
+
+{% block title %}<a href="{% url 'people:contributions' person.login %}">{{ contribution_list_title }}</a> &rarr; {{ contribution_title }}{% endblock %}
+
+{% block content %}
+
+<form method="post">
+    {% csrf_token %}
+
+    <div class="t-row">
+        <div class="t-cell form-label">Project:</div>
+        <div class="t-cell form-field">{{ contribution_form.project }}</div>
+    </div>
+    {% if contribution_form.project.errors %}
+        <div class="t-row">
+            <div class="t-cell form-label">&nbsp;</div>
+            <div class="t-cell form-field">{{ contribution_form.project.errors }}</div>
+        </div>
+    {% endif %}
+    <div class="t-row">
+        <div class="t-cell form-label">Description:</div>
+        <div class="t-cell form-field" id="description">{{ contribution_form.description }}</div>
+    </div>
+
+    {% if can_edit %}
+        <hr>
+        <div class="t-row">
+            <div class="t-cell"><button type="submit">Submit</button></div>
+        </div>
+    {% endif %}
+</form>
+
+{% endblock %}
+

--- a/people/templates/people/contributions.html
+++ b/people/templates/people/contributions.html
@@ -1,0 +1,49 @@
+{% extends "people/base.html" %}
+{% load i18n %}{% load markdownify %}
+
+{% block title %}
+    {% if can_edit %}
+        {% translate "My contributions" %}
+    {% else %}
+        {% url 'root:person' person.login as person_url %}
+        {% blocktranslate %}<a href="{{ person_url }}">{{ person }}</a>'s contributions{% endblocktranslate %}
+    {% endif %}
+{% endblock %}
+
+{% block quick_link %}
+    {% if can_edit %}
+        <a href="{% url 'people:contribution-new' %}">Add new…</a>
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+
+{% for contribution in contributions %}
+    <div class="t-row-nth">
+        <div class="t-cell people-person-contributions-project-cell">
+            <a href="{% url 'skills:project' contribution.project.id %}">{{ contribution.project }}</a>
+        </div>
+        <div class="t-cell people-person-contributions-details-cell">
+            <div class="t-row">
+                <div class="t-cell">
+                    {{ contribution.description|markdownify }}
+                </div>
+            </div>
+            <div class="t-row">
+                <div class="t-cell">
+                    {% for skill in contribution.skills.all %}
+                        <span class="people-person-contribution-project-skill">{{ skill.name }}</span>
+                    {% endfor %}
+                </div>
+            </div>
+            <div class="t-row">
+                <div class="t-cell">
+                    <a href="{% url 'people:contribution' contribution.id %}">Edit…</a>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endfor %}
+
+{% endblock %}
+

--- a/team/settings.py
+++ b/team/settings.py
@@ -123,6 +123,7 @@ MARKDOWNIFY_WHITELIST_TAGS = [
     'acronym',
     'b',
     'blockquote',
+    'br',
     'em',
     'h2', 'h3', 'h4', 'h5', 'h6',
     'i',


### PR DESCRIPTION
This patch adds HTML templates needed for displaying and editing the personal contribution, and also fixes the set of tags allowed for the Markdown to HTML conversion.

This is related to https://github.com/Igalia/team/issues/33.