### PR TITLE
Extracted the default user to the settings

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -6,4 +6,4 @@ from django.conf import settings
 def get_user_login(request):
     if settings.USE_BASIC_AUTH:
         return base64.b64decode(request.META['HTTP_AUTHORIZATION'].split()[1]).decode('utf8').split(':')[0]
-    return 'average_joe'
+    return settings.AUTH_FALLBACK_USER

--- a/team/settings.py
+++ b/team/settings.py
@@ -90,6 +90,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+AUTH_FALLBACK_USER = 'average_joe'
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/


### PR DESCRIPTION
This patch extracts the default 'stub user' into settings, which helps local development and testing.