### PR TITLE
Added the navigation menu at the people:person page

### DIFF
--- a/people/templates/people/base.html
+++ b/people/templates/people/base.html
@@ -4,3 +4,25 @@
 {% block head %}
     <link rel="stylesheet" type="text/css" href="{% static 'people/style.css' %}">
 {% endblock %}
+
+{% block second_level_menu %}
+    <div class="menu-bar">
+        <div class="menu">
+            {% get_menu "NAV_MENU_2ND_LEVEL" as menu %}
+            {% for item in menu %}
+                <li class="{% if item.selected %} active {% endif %}">
+                    <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
+                </li>
+                {% if item.submenu %}
+                    <ul>
+                        {% for menu in item.submenu %}
+                            <li class="{% if menu.selected %} active {% endif %}">
+                                <a href="{{ menu.url }}">{{ menu.name }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endfor %}
+        </div>
+    </div>
+{% endblock %}

--- a/people/templates/people/base.html
+++ b/people/templates/people/base.html
@@ -10,18 +10,9 @@
         <div class="menu">
             {% get_menu "NAV_MENU_2ND_LEVEL" as menu %}
             {% for item in menu %}
-                <li class="{% if item.selected %} active {% endif %}">
+                <div class="{% if item.selected %} active {% endif %}">
                     <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
-                </li>
-                {% if item.submenu %}
-                    <ul>
-                        {% for menu in item.submenu %}
-                            <li class="{% if menu.selected %} active {% endif %}">
-                                <a href="{{ menu.url }}">{{ menu.name }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+                </div>
             {% endfor %}
         </div>
     </div>

--- a/people/templates/people/contribution.html
+++ b/people/templates/people/contribution.html
@@ -31,4 +31,3 @@
 </form>
 
 {% endblock %}
-

--- a/people/templates/people/contributions.html
+++ b/people/templates/people/contributions.html
@@ -46,4 +46,3 @@
 {% endfor %}
 
 {% endblock %}
-

--- a/people/templates/people/person.html
+++ b/people/templates/people/person.html
@@ -1,17 +1,15 @@
 {% extends "people/base.html" %}
 {% load menu_generator %}{% load static %}
 
-{% block second_level_menu %}
+{% block title %}{{ person | default_if_none:"Person not found" }}{% endblock %}
+
+{% block content %}
+
 <form method="post" autocomplete="off" id="id_search_form">
     {% csrf_token %}
 
     <div class="people-autocomplete">{{ search_form.login }}</div>
 </form>
-{% endblock %}
-
-{% block title %}{{ person | default_if_none:"Person not found" }}{% endblock %}
-
-{% block content %}
 
 {% if person %}
 <div class="t-row">

--- a/skills/templates/skills/base.html
+++ b/skills/templates/skills/base.html
@@ -10,18 +10,9 @@
         <div class="menu">
             {% get_menu "NAV_MENU_2ND_LEVEL" as menu %}
             {% for item in menu %}
-                <li class="{% if item.selected %} active {% endif %}">
+                <div class="{% if item.selected %} active {% endif %}">
                     <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
-                </li>
-                {% if item.submenu %}
-                    <ul>
-                        {% for menu in item.submenu %}
-                            <li class="{% if menu.selected %} active {% endif %}">
-                                <a href="{{ menu.url }}">{{ menu.name }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+                </div>
             {% endfor %}
         </div>
 

--- a/static/style.css
+++ b/static/style.css
@@ -59,18 +59,9 @@ a:hover {
     overflow: hidden;
 }
 
-.menu li {
+.menu div {
     float: left;
-}
-
-.menu li a {
-    display: block;
-    text-align: center;
     padding: 14px 16px;
-}
-
-.menu li a.active {
-    float: right;
 }
 
 .active {

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,18 +13,9 @@
                 <div class="menu">
                     {% get_menu "NAV_MENU_1ST_LEVEL" as menu %}
                     {% for item in menu %}
-                        <li class="{% if item.selected %} active {% endif %}">
+                        <div class="{% if item.selected %} active {% endif %}">
                             <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
-                        </li>
-                        {% if item.submenu %}
-                            <ul>
-                                {% for menu in item.submenu %}
-                                    <li class="{% if menu.selected %} active {% endif %}">
-                                        <a href="{{ menu.url }}">{{ menu.name }}</a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        {% endif %}
+                        </div>
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
This patch adds the second level navigation menu at the Person page, which prepares it for coming changes that will plumb Teams and People Picker pages.

This is related to https://github.com/Igalia/team/issues/91