### PR TITLE
Added templates for team views

### DIFF
--- a/people/templates/people/team.html
+++ b/people/templates/people/team.html
@@ -1,0 +1,27 @@
+
+{% extends "people/base.html" %}
+{% load markdownify %}
+
+{% block title %}{{ team | default_if_none:"Team not found" }}{% endblock %}
+
+{% block content %}
+
+{{ team.description|markdownify }}
+
+<h2>Members</h2>
+
+<ul>
+{% for person in team.person_set.all %}
+    <li><a href="{% url 'root:person' person.login %}">{{ person }}</a></li>
+{% endfor %}
+</ul>
+
+<h2>Projects</h2>
+
+<ul>
+{% for project in team.project_set.all %}
+    <li><a href="{% url 'skills:project' project.id %}">{{ project }}</a></li>
+{% endfor %}
+</ul>
+
+{% endblock %}

--- a/people/templates/people/teams.html
+++ b/people/templates/people/teams.html
@@ -8,11 +8,14 @@
 {% for team in teams %}
     <div class="people-teams-team">
         <h2><a href="{% url 'people:team' team.slug %}">{{ team }}</a></h2>
-        <p><small>{{ team.person_set.all|length }} member(s) in this team:
-        {% for person in team.person_set.all %}
-            <a href="{% url 'root:person' person.login %}">{{ person.login }}</a>
-        {% endfor %}
-    </small></p>
+        <p>
+            <small>
+                {{ team.person_set.all|length }} member(s) in this team:
+                {% for person in team.person_set.all %}
+                <a href="{% url 'root:person' person.login %}">{{ person.login }}</a>
+                {% endfor %}
+            </small>
+        </p>
     </div>
 {% endfor %}
 

--- a/people/templates/people/teams.html
+++ b/people/templates/people/teams.html
@@ -1,0 +1,19 @@
+{% extends "people/base.html" %}
+{% load menu_generator %}
+
+{% block title %}Teams{% endblock %}
+
+{% block content %}
+
+{% for team in teams %}
+    <div class="people-teams-team">
+        <h2><a href="{% url 'people:team' team.slug %}">{{ team }}</a></h2>
+        <p><small>{{ team.person_set.all|length }} member(s) in this team:
+        {% for person in team.person_set.all %}
+            <a href="{% url 'root:person' person.login %}">{{ person.login }}</a>
+        {% endfor %}
+    </small></p>
+    </div>
+{% endfor %}
+
+{% endblock %}


### PR DESCRIPTION
This patch introduces templates for two more pages, the list of teams and the individual team that lists projects (which are related to personal contributions).

This is related to https://github.com/Igalia/team/issues/33