### PR TITLE
Re-organised the menus and arranged logically the People part

### DIFF
--- a/people/menus.py
+++ b/people/menus.py
@@ -2,6 +2,7 @@
 
 def in_app(request):
     """Returns whether `request` would be handled by this app.
+
     This is a validator for the menu.  It hides the People second level menu when views from other apps are rendered.
     """
     return 'people' in request.resolver_match.app_names or 'root' in request.resolver_match.app_names

--- a/people/menus.py
+++ b/people/menus.py
@@ -1,6 +1,16 @@
+# This is the only `menus.py` that has `NAV_MENU_1ST_LEVEL`.  In all other apps only the `NAV_MENU_2ND_LEVEL` is needed.
+
+def in_app(request):
+    """Returns whether `request` would be handled by this app.
+    This is a validator for the menu.  It hides the People second level menu when views from other apps are rendered.
+    """
+    return 'people' in request.resolver_match.app_names or 'root' in request.resolver_match.app_names
+
+
 MENUS = {
     'NAV_MENU_1ST_LEVEL': [
         {
+            "is_people_app": True,  # This is part of a hack to force "active" state for the root:person view.
             "name": "People",
             "url": "people:home",
             'root': True,
@@ -9,6 +19,27 @@ MENUS = {
             "name": "Skills",
             "url": "skills:home",
             'root': True,
+        },
+    ],
+    "NAV_MENU_2ND_LEVEL": [
+        {
+            "is_person_view": True,  # This is part of a hack to force "active" state for the root:person view.
+            "name": "Home",
+            "url": "people:home",
+            "root": False,
+            "validators": ["people.menus.in_app"],
+        },
+        {
+            "name": "Teams",
+            "url": "people:teams",
+            "root": False,
+            "validators": ["people.menus.in_app"],
+        },
+        {
+            "name": "People picker",
+            "url": "people:picker",
+            "root": False,
+            "validators": ["people.menus.in_app"],
         },
     ],
 }

--- a/people/root_urls.py
+++ b/people/root_urls.py
@@ -1,0 +1,27 @@
+"""URL configuration of the People application.
+
+The People application provides a couple of "root" URL for showing personal pages.  These are the "/" which shows the
+personal page of the current user and "/<person-login>" which show pages of other people.
+
+Due to how the URL resolver logic works, this sub-section is assigned to a virtual `root` application name.
+"""
+
+from django.http.response import HttpResponseRedirect
+from django.urls import path, reverse
+
+from common.auth import get_user_login
+from . import views
+
+
+# noinspection PyUnusedLocal
+def home(request):
+    return HttpResponseRedirect(reverse('root:person', args=[get_user_login(request)]))
+
+
+app_name = 'root'
+urlpatterns = [
+    # Redirects to the personal page of "ourselves" (the current user).
+    path('', home, name='home'),
+    # Shows a personal page of a person with `login`.
+    path('<str:login>', views.render_person, name='person'),
+]

--- a/people/templates/people/base.html
+++ b/people/templates/people/base.html
@@ -10,9 +10,15 @@
         <div class="menu">
             {% get_menu "NAV_MENU_2ND_LEVEL" as menu %}
             {% for item in menu %}
-                <div class="{% if item.selected %} active {% endif %}">
-                    <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
-                </div>
+                {% if item.is_person_view and at_person_view %}
+                    <div class="active">
+                        <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
+                    </div>
+                {% else %}
+                    <div class="{% if item.selected %} active {% endif %}">
+                        <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
+                    </div>
+                {% endif %}
             {% endfor %}
         </div>
     </div>

--- a/people/templates/people/contributions.html
+++ b/people/templates/people/contributions.html
@@ -5,7 +5,7 @@
     {% if can_edit %}
         {% translate "My contributions" %}
     {% else %}
-        {% url 'people:person' person.login as person_url %}
+        {% url 'root:person' person.login as person_url %}
         {% blocktranslate %}<a href="{{ person_url }}">{{ person }}</a>'s contributions{% endblocktranslate %}
     {% endif %}
 {% endblock %}

--- a/people/templates/people/person.html
+++ b/people/templates/people/person.html
@@ -37,7 +37,7 @@
 
                 <div class="t-row">
                     <div class="t-cell">Teams:</div>
-                    <div class="t-cell">{% for team in person.teams.all %}{{ team }}{% endfor %}</div>
+                    <div class="t-cell">{% for team in person.teams.all %}<a href="{% url 'people:team' team.slug %}">{{ team }}</a>{% endfor %}</div>
                 </div>
             </div>
 

--- a/people/templates/people/team.html
+++ b/people/templates/people/team.html
@@ -11,7 +11,7 @@
 
 <ul>
 {% for person in team.person_set.all %}
-    <li><a href="{% url 'people:person' person.login %}">{{ person }}</a></li>
+    <li><a href="{% url 'root:person' person.login %}">{{ person }}</a></li>
 {% endfor %}
 </ul>
 

--- a/people/templates/people/teams.html
+++ b/people/templates/people/teams.html
@@ -12,7 +12,7 @@
             <small>
                 {{ team.person_set.all|length }} member(s) in this team:
                 {% for person in team.person_set.all %}
-                <a href="{% url 'people:person' person.login %}">{{ person.login }}</a>
+                <a href="{% url 'root:person' person.login %}">{{ person.login }}</a>
                 {% endfor %}
             </small>
         </p>

--- a/people/urls.py
+++ b/people/urls.py
@@ -1,6 +1,6 @@
 """URL configuration of the People application.
 
-The People application is
+This is the main section for the URL map. See also `.root_urls.py`.
 """
 
 from django.http.response import HttpResponseRedirect
@@ -12,7 +12,7 @@ from . import views
 
 # noinspection PyUnusedLocal
 def home(request):
-    return HttpResponseRedirect(reverse('people:person', args=[get_user_login(request)]))
+    return HttpResponseRedirect(reverse('root:person', args=[get_user_login(request)]))
 
 
 app_name = 'people'

--- a/people/views.py
+++ b/people/views.py
@@ -68,7 +68,7 @@ def render_person(request, login):
 
     try:
         if request.method == 'POST' and search_form.is_valid():
-            return HttpResponseRedirect(reverse('people:person', args=[search_form.cleaned_data['login']]))
+            return HttpResponseRedirect(reverse('root:person', args=[search_form.cleaned_data['login']]))
 
         person = Person.objects.get(login=login)
         try:
@@ -82,9 +82,14 @@ def render_person(request, login):
             personal_data_form = PersonalDataForm(request.POST or None, instance=personal_data)
             if request.method == 'POST' and personal_data_form.is_valid():
                 personal_data_form.save()
-                return HttpResponseRedirect(reverse('people:person', args=[login]))
+                return HttpResponseRedirect(reverse('root:person', args=[login]))
 
-        context = {'can_edit': can_edit,
+        # The `at_person_view` flag is part of a hack to force "active" state for the root:person view.
+        # Django-menu-generator does not seem to recognise that URL as "child" for the People app, and does not activate
+        # the menu item as expected.  That is why we have explicit flags set for these two menu items, and the templates
+        # detect them when rendering the menu.
+        context = {'at_person_view': True,
+                   'can_edit': can_edit,
                    'inventory': Device.objects.filter(assignee=person),
                    'people': people,
                    'person': person,

--- a/people/views.py
+++ b/people/views.py
@@ -84,10 +84,10 @@ def render_person(request, login):
                 personal_data_form.save()
                 return HttpResponseRedirect(reverse('root:person', args=[login]))
 
-        # The `at_person_view` flag is part of a hack to force "active" state for the root:person view.
+        # The `at_person_view` flag is part of a hack to force "active" state for the menu item for the root:person URL.
         # Django-menu-generator does not seem to recognise that URL as "child" for the People app, and does not activate
-        # the menu item as expected.  That is why we have explicit flags set for these two menu items, and the templates
-        # detect them when rendering the menu.
+        # the menu item as expected.  That is why we set explicit flags for these two menu items, and the templates look
+        # at them when rendering the menu.
         context = {'at_person_view': True,
                    'can_edit': can_edit,
                    'inventory': Device.objects.filter(assignee=person),

--- a/skills/menus.py
+++ b/skills/menus.py
@@ -3,6 +3,7 @@ from people.models import Team
 
 def in_app(request):
     """Returns whether `request` would be handled by this app.
+
     This is a validator for the menu.  It hides the Skills second level menu when views from other apps are rendered.
     """
     return 'skills' in request.resolver_match.app_names

--- a/skills/menus.py
+++ b/skills/menus.py
@@ -1,5 +1,13 @@
 from people.models import Team
 
+
+def in_app(request):
+    """Returns whether `request` would be handled by this app.
+    This is a validator for the menu.  It hides the Skills second level menu when views from other apps are rendered.
+    """
+    return 'skills' in request.resolver_match.app_names
+
+
 # noinspection PyUnresolvedReferences
 MENUS = {
     "NAV_MENU_1ST_LEVEL": [],
@@ -7,19 +15,20 @@ MENUS = {
         {
             "name": "Interest vs. Knowledge",
             "url": "skills:interest-vs-knowledge",
-            "root": True,
+            "root": False,
+            "validators": ["skills.menus.in_app"],
         },
         {
             "name": "Projects",
             "url": "skills:projects",
-            "root": True,
-            "validators": ["skills.views.enable_projects"],
+            "root": False,
+            "validators": ["skills.views.enable_projects", "skills.menus.in_app"],
         },
         {
             "name": "Demand vs. Knowledge",
             "url": "skills:demand-vs-knowledge",
             "root": True,
-            "validators": ["skills.views.enable_projects"],
+            "validators": ["skills.views.enable_projects", "skills.menus.in_app"],
         },
     ],
     "NAV_MENU_TEAM_SELECTOR": [

--- a/team/urls.py
+++ b/team/urls.py
@@ -13,13 +13,13 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.contrib import admin
-from django.urls import path, reverse
 from django.conf.urls import include
-
+from django.contrib import admin
+from django.urls import path
 
 urlpatterns = [
-    path('', include('people.urls', namespace='people')),
+    path('', include('people.root_urls', namespace='root')),
+    path('people/', include('people.urls', namespace='people')),
     path('admin/', admin.site.urls),
     path('ballots/', include('ballots.urls', namespace='ballots')),
     path('skills/', include('skills.urls', namespace='skills')),

--- a/templates/base.html
+++ b/templates/base.html
@@ -13,9 +13,15 @@
                 <div class="menu">
                     {% get_menu "NAV_MENU_1ST_LEVEL" as menu %}
                     {% for item in menu %}
-                        <div class="{% if item.selected %} active {% endif %}">
-                            <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
-                        </div>
+                        {% if item.is_people_app and at_person_view %}
+                            <div class="active">
+                                <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
+                            </div>
+                        {% else %}
+                            <div class="{% if item.selected %} active {% endif %}">
+                                <a href="{{ item.url }}"> <i class="{{ item.icon_class }}"></i> {{ item.name }}</a>
+                            </div>
+                        {% endif %}
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
With the recent additions to the People app, the navigation needed to be updated.  This patch closes the gap by adding the second level menu in the People app, and also adds the logic that hides menus from other apps, and highlights the menu item for the current page.

This is related to https://github.com/Igalia/team/issues/91